### PR TITLE
更新學習資源頁面：修正失效連結並新增推薦資源

### DIFF
--- a/resources/links.html
+++ b/resources/links.html
@@ -171,6 +171,30 @@
                                 <td>技術深入、持續更新</td>
                                 <td><a href="https://www.promptingguide.ai/" target="_blank">前往</a></td>
                             </tr>
+                            <tr>
+                                <td><strong>Prompt Engineering for ChatGPT</strong></td>
+                                <td>Vanderbilt 大學 Coursera 課程，7600+ 評價</td>
+                                <td>免費旁聽、大學認證、初學者友善</td>
+                                <td><a href="https://www.coursera.org/learn/prompt-engineering" target="_blank">前往</a></td>
+                            </tr>
+                            <tr>
+                                <td><strong>ChatGPT Prompt Engineering for Developers</strong></td>
+                                <td>吳恩達與 OpenAI 合作的免費短期課程</td>
+                                <td>免費、實作導向、適合進階學習</td>
+                                <td><a href="https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/" target="_blank">前往</a></td>
+                            </tr>
+                            <tr>
+                                <td><strong>OpenAI Prompt Engineering Guide</strong></td>
+                                <td>OpenAI 官方 Prompt 工程最佳實踐指南</td>
+                                <td>官方指南、最新技巧</td>
+                                <td><a href="https://platform.openai.com/docs/guides/prompt-engineering" target="_blank">前往</a></td>
+                            </tr>
+                            <tr>
+                                <td><strong>Anthropic Courses</strong></td>
+                                <td>Anthropic 官方 GitHub 教學課程（含 Prompt 工程、工具使用等）</td>
+                                <td>免費、含練習、18k+ 星</td>
+                                <td><a href="https://github.com/anthropics/courses" target="_blank">前往</a></td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>
@@ -220,7 +244,7 @@
                 <div class="content-section" style="margin-top: 30px;">
                     <h3>主要 LLM 平台</h3>
                     <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px;">
-                        <a href="https://chat.openai.com" target="_blank" class="card" style="text-decoration: none; text-align: center;">
+                        <a href="https://chatgpt.com" target="_blank" class="card" style="text-decoration: none; text-align: center;">
                             <h4 style="color: var(--text-color); margin-bottom: 8px;">ChatGPT</h4>
                             <p style="color: var(--text-muted); font-size: 0.9rem; margin: 0;">OpenAI</p>
                         </a>
@@ -325,6 +349,21 @@
                                 <td><strong>Hahow 好學校</strong></td>
                                 <td>台灣線上課程平台，有 AI 相關課程</td>
                                 <td><a href="https://hahow.in/" target="_blank">前往</a></td>
+                            </tr>
+                            <tr>
+                                <td><strong>e等公務園＋學習平臺</strong></td>
+                                <td>公務人員數位學習平臺，含 AI 公務應用、AI 增能工作坊等課程</td>
+                                <td><a href="https://elearn.hrd.gov.tw/" target="_blank">前往</a></td>
+                            </tr>
+                            <tr>
+                                <td><strong>數發部資訊職能數位學習區</strong></td>
+                                <td>數位發展部 AI 學習資源，公務人員與民眾皆可免費使用</td>
+                                <td><a href="https://moda.elearn.hrd.gov.tw/" target="_blank">前往</a></td>
+                            </tr>
+                            <tr>
+                                <td><strong>台大李宏毅教授 — 生成式 AI 導論</strong></td>
+                                <td>台灣大學免費開放課程，中文授課，涵蓋 LLM 原理與 Prompt 技巧</td>
+                                <td><a href="https://speech.ee.ntu.edu.tw/~hylee/genai/2024-spring.php" target="_blank">前往</a></td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
- 修正 ChatGPT 連結從 chat.openai.com 改為 chatgpt.com（舊網域已重導向）
- 免費學習平台新增：Vanderbilt Prompt Engineering 課程、吳恩達 DeepLearning.AI 短期課程、OpenAI 官方 Prompt 工程指南、Anthropic Courses GitHub 教學庫
- 中文資源新增：e等公務園＋學習平臺、數發部資訊職能數位學習區、 台大李宏毅教授生成式 AI 導論課程

https://claude.ai/code/session_011nRVQc9xxVYs185LqjKNwo