### PR TITLE
Fix RWD issues and update project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,16 @@ Or just open `index.html` directly in a browser. There is no build step, no pack
 
 - `index.html` — Landing page with learning map and module grid
 - `modules/module0-5.html` — 6 course modules, each with sidebar unit navigation and a main content area containing units
+- `certificate.html` — Graduation certificate page (unlocked when all modules complete and final quiz ≥ 80%)
 - `recipes/prompt-recipes.html` — 20+ reusable prompt templates across 4 categories, each with copy-to-clipboard
 - `resources/links.html` — Curated external learning resources
 - `docs/影片腳本.md` — Video scripts for all modules (production reference)
+- `slides/` — Python slide generation scripts (python-pptx, managed via `uv`)
+  - `shared.py` — Brand constants and 15 reusable slide builder functions
+  - `generate_module0-5.py` — One script per module
+  - `generate_all.py` — Batch runner (`cd slides && uv run python generate_all.py`)
+  - `output/` — 6 generated `.pptx` files (115 slides total, 56–64 KB each)
+  - `output/pdf/` — PDF versions of slides (exported by user after generation)
 
 ## Interactive Components
 
@@ -47,7 +54,7 @@ Each module page may contain these component types, all driven by `main.js`:
 | Fill-in-the-blank | `.fill-blank-container` with inputs/selects | `checkFillBlankAnswer()` / `showFillBlankAnswers()` |
 | Scenario questions | `.scenario-container` | `checkScenarioAnswer()` |
 | Checklists | `.checklist` with checkboxes | `initChecklists()` (auto-persisted) |
-| Copy buttons | `.copy-btn` with `data-clipboard-target` | `initCopyButtons()` |
+| Copy buttons | `.btn-copy` with `data-copy-target` | `initCopyButtons()` |
 | Tabs / Accordions | `.tab-btn` / `.accordion-header` | `initTabs()` / `initAccordions()` |
 
 ## Key Conventions
@@ -57,4 +64,4 @@ Each module page may contain these component types, all driven by `main.js`:
 - Fill-in-the-blank accepts multiple answers separated by `|` (pipe), matching is case-insensitive
 - Unit navigation uses `showUnit(moduleId, unitIndex)` — called from sidebar links
 - Completion is tracked per-unit; module auto-completes when all units are done
-- Video sections use placeholder containers ready for YouTube iframe embeds
+- Video sections embed YouTube iframes via `.video-container` (16:9 padding-bottom aspect-ratio wrapper); a PDF slide deck download link (`../slides/output/pdf/`) appears below each video

--- a/README.md
+++ b/README.md
@@ -11,16 +11,18 @@
 | 模組 2 | Prompt 四要素 | 撰寫有效 Prompt 的方法 |
 | 模組 3 | 文書處理應用 | AI 輔助日常文書工作 |
 | 模組 4 | 資料整理應用 | AI 輔助資料分析與整理 |
-| 模組 5 | 進階技巧與測驗 | 進階應用與期末測驗 |
+| 模組 5 | 進階技巧 | 多輪對話、迭代優化、常見錯誤與避坑指南 |
 
 ## 功能特色
 
+- **教學影片** — 每個模組嵌入對應 YouTube 教學影片，支援全螢幕播放
+- **投影片下載** — 每部影片下方提供 PDF 投影片下載連結
 - **互動式測驗** — 單選、多選、拖曳排序、填空等多種題型
 - **Prompt 食譜** — 20+ 可直接複製使用的 Prompt 範本
 - **學習進度追蹤** — 自動記錄各模組完成狀態（LocalStorage）
 - **學習地圖** — 視覺化呈現整體學習進度
 - **結業證書** — 完成所有模組且期末測驗達 80% 即可取得
-- **響應式設計** — 支援桌機、平板、手機瀏覽
+- **響應式設計** — 支援桌機、平板、手機瀏覽（RWD）
 
 ## 技術架構
 
@@ -30,15 +32,22 @@
 ├── index.html              # 首頁（學習地圖、模組總覽）
 ├── certificate.html        # 結業證書頁面
 ├── modules/
-│   └── module0-5.html      # 6 個課程模組
+│   └── module0-5.html      # 6 個課程模組（含嵌入式 YouTube 影片）
 ├── recipes/
 │   └── prompt-recipes.html # Prompt 食譜
 ├── resources/
 │   └── links.html          # 延伸學習資源
 ├── css/
-│   └── style.css           # 全站樣式（CSS Custom Properties）
+│   └── style.css           # 全站樣式（CSS Custom Properties、RWD 斷點）
 ├── js/
 │   └── main.js             # 全站互動邏輯
+├── slides/
+│   ├── shared.py           # 品牌常數與共用投影片函數
+│   ├── generate_module0-5.py  # 6 個模組投影片腳本（python-pptx）
+│   ├── generate_all.py     # 批次執行入口
+│   └── output/
+│       ├── *.pptx          # 6 份 PowerPoint 投影片（115 張）
+│       └── pdf/            # PDF 版投影片（供下載）
 └── docs/
     └── 影片腳本.md          # 教學影片腳本
 ```
@@ -56,6 +65,16 @@ npx serve .
 ```
 
 然後開啟 http://localhost:8000 即可。也可以直接在瀏覽器開啟 `index.html`。
+
+### 重新生成投影片（選用）
+
+需要先安裝 [uv](https://docs.astral.sh/uv/)：
+
+```bash
+cd slides
+uv run python generate_all.py
+# 輸出至 slides/output/（6 份 .pptx，共 115 張）
+```
 
 ## License
 

--- a/css/style.css
+++ b/css/style.css
@@ -1497,6 +1497,30 @@ footer {
         width: 100%;
         justify-content: center;
     }
+
+    /* Fill-in-the-blank inputs: remove fixed min-width on mobile */
+    .fill-blank-input,
+    .fill-blank-select {
+        min-width: 0;
+        max-width: 100%;
+    }
+
+    /* Drag-drop: compact padding and full-width drop zones on mobile */
+    .drag-drop-container {
+        padding: 16px;
+    }
+
+    .drop-zone {
+        min-width: 0;
+        width: 100%;
+    }
+
+    /* Tabs: horizontal scroll instead of wrapping/overflow on mobile */
+    .tabs {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        flex-wrap: nowrap;
+    }
 }
 
 @media (max-width: 480px) {
@@ -1518,6 +1542,9 @@ footer {
 
     .resource-table {
         font-size: 0.9rem;
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
     }
 
     .resource-table th,

--- a/modules/module3.html
+++ b/modules/module3.html
@@ -165,9 +165,9 @@
                                             <option value="旅遊部落客">旅遊部落客</option>
                                         </select>
                                         。請撰寫發文給
-                                        <input type="text" class="fill-blank-input" data-answer="各縣市衛生局" placeholder="輸入發文對象..." style="width: 150px;">
+                                        <input type="text" class="fill-blank-input" data-answer="各縣市衛生局" placeholder="輸入發文對象...">
                                         的函文，主旨為
-                                        <input type="text" class="fill-blank-input" data-answer="防疫物資配送|防疫物資配送事宜" placeholder="輸入主旨..." style="width: 200px;">
+                                        <input type="text" class="fill-blank-input" data-answer="防疫物資配送|防疫物資配送事宜" placeholder="輸入主旨...">
                                     </p>
                                     <div style="margin-top: 16px;">
                                         <button class="btn btn-primary" onclick="checkFillBlankAnswer('doc-practice')">檢查答案</button>


### PR DESCRIPTION
RWD fixes (css/style.css):
- fill-blank inputs/selects: remove min-width on mobile (≤768px) to prevent horizontal overflow on narrow screens
- drop-zone: remove min-width, go full-width on mobile (≤768px)
- drag-drop-container: reduce padding to 16px on mobile (≤768px)
- tabs: add overflow-x scroll + nowrap on mobile (≤768px) to prevent overflow
- resource-table: add display:block + overflow-x:auto on small screens (≤480px) so multi-column tables scroll horizontally instead of overflowing

HTML fix (modules/module3.html):
- Remove inline style="width: 150px/200px" from fill-blank inputs; inline styles were overriding CSS and preventing RWD fixes from taking effect

CLAUDE.md:
- Add certificate.html to Content Structure
- Add slides/ directory description (python-pptx, uv, output structure)
- Fix copy button docs: .copy-btn/data-clipboard-target → .btn-copy/data-copy-target
- Update video section convention: placeholders → live YouTube iframes + PDF links

README.md:
- Add 教學影片 and 投影片下載 to feature list
- Fix module 5 description (進階技巧與測驗 → 進階技巧)
- Add slides/ subtree to architecture diagram
- Add slide regeneration command (uv run python generate_all.py)

https://claude.ai/code/session_01GvsFbY8GPsoacyB9tK8Rpx