### PR TITLE
Add auto-hide sidebar on mobile scroll for better reading experience

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1387,6 +1387,13 @@ footer {
         max-width: 100%;
         background: var(--bg-color);
         padding: 10px 0;
+        transition: transform 0.3s ease, opacity 0.2s ease;
+    }
+
+    .module-sidebar.sidebar-hidden {
+        transform: translateY(-100%);
+        opacity: 0;
+        pointer-events: none;
     }
 
     .module-nav {

--- a/js/main.js
+++ b/js/main.js
@@ -29,6 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initChecklists();
     initCopyButtons();
     initModuleNavigation();
+    initSidebarAutoHide();
     updateProgressDisplay();
     initLearningMap();
 });
@@ -742,6 +743,10 @@ function getCurrentUnitIndex() {
 }
 
 function showUnit(index) {
+    // Show sidebar when switching units (may be hidden by scroll)
+    const sidebar = document.querySelector('.module-sidebar');
+    if (sidebar) sidebar.classList.remove('sidebar-hidden');
+
     const units = document.querySelectorAll('.unit-container');
     const navLinks = document.querySelectorAll('.module-nav-link');
 
@@ -787,6 +792,42 @@ function updateNavigationButtons(currentIndex, totalUnits) {
         nextBtn.style.display = isLastUnit ? 'none' : 'inline-flex';
         completeBtn.style.display = isLastUnit ? 'inline-flex' : 'none';
     }
+}
+
+// ==================== Sidebar Auto-Hide on Mobile ====================
+function initSidebarAutoHide() {
+    const sidebar = document.querySelector('.module-sidebar');
+    if (!sidebar) return;
+
+    let lastScrollY = window.scrollY;
+    let ticking = false;
+    const SCROLL_THRESHOLD = 10;
+
+    window.addEventListener('scroll', () => {
+        if (ticking) return;
+        ticking = true;
+
+        requestAnimationFrame(() => {
+            const currentScrollY = window.scrollY;
+            const delta = currentScrollY - lastScrollY;
+            const isMobile = window.matchMedia('(max-width: 860px)').matches;
+
+            if (isMobile && Math.abs(delta) > SCROLL_THRESHOLD) {
+                if (delta > 0 && currentScrollY > 150) {
+                    sidebar.classList.add('sidebar-hidden');
+                } else if (delta < 0) {
+                    sidebar.classList.remove('sidebar-hidden');
+                }
+            }
+
+            if (!isMobile) {
+                sidebar.classList.remove('sidebar-hidden');
+            }
+
+            lastScrollY = currentScrollY;
+            ticking = false;
+        });
+    });
 }
 
 function showCompletionModal(moduleId) {


### PR DESCRIPTION
On mobile (≤860px), the sticky unit navigation bar now:
- Hides with a slide-up animation when scrolling down (after 150px)
- Reappears when scrolling up or switching units
- Uses requestAnimationFrame throttling and a 10px scroll threshold to prevent jitter from minor touch movements
- Desktop layout is unaffected

https://claude.ai/code/session_01GvsFbY8GPsoacyB9tK8Rpx